### PR TITLE
fix: various build problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,34 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.23)
 project(croco VERSION 0.2.0)
 
-set(CMAKE_C_STANDART 11)
-set(CMAKE_C_STANDART_REQUIRED ON)
-
 find_package(Curses REQUIRED)
-include_directories(${CURSES_INCLUDE_DIR})
 
-set (SOURSES
-	src/commands.c
-	src/croco.c
-	src/files.c
-	src/util.c
+# FindCurses hasn't been updated to use modern CMake, so do it ourselves
+add_library(Curses::Curses INTERFACE IMPORTED)
+target_include_directories(Curses::Curses INTERFACE ${CURSES_INCLUDE_DIRS})
+target_link_libraries(Curses::Curses INTERFACE ${CURSES_LIBRARIES})
+target_compile_options(Curses::Curses INTERFACE ${CURSES_CFLAGS})
+
+add_executable(croco)
+
+target_compile_features(croco
+  PRIVATE
+    c_std_11
 )
 
-add_executable(${PROJECT_NAME} ${SOURSES})
+target_sources(croco
+  PRIVATE
+    src/commands.c
+    src/croco.c
+    src/files.c
+    src/util.c
 
-target_link_libraries(${PROJECT_NAME} ${CURSES_LIBRARIES})
+  PRIVATE
+    FILE_SET HEADERS
+    BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/inc
+)
 
+target_link_libraries(croco 
+  PRIVATE 
+    Curses::Curses
+)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CC_FLAGS = -g -W -Werror -Wall -Wpedantic -std=c11 
+CC_FLAGS = -g -W -Werror -Wall -Wpedantic -std=c11
 
 TARGET = croco
 
@@ -10,7 +10,7 @@ SOURCES = $(SRC_DIR)/*.c
 
 DEL_FILE = rm -f
 MKDIR_P = mkdir -p
-LIBS_DIRS = -I/.include/
+LIBS_DIRS = -Iinc
 LIBS = $(LIBS_DIRS) -lncurses -lc
 
 .PHONY: clean build
@@ -25,4 +25,3 @@ run:
 clean:
 	${MKDIR_P} ${BIN_DIR}
 	$(DEL_FILE) $(BIN_DIR)/*
-

--- a/inc/croco.h
+++ b/inc/croco.h
@@ -27,7 +27,7 @@
  * max len of folder/file title
  */
 #define DIRS_MAX  32000
-#define PATH_MAX  1600
+#define CROCO_PATH_MAX  1600
 #define TITLE_MAX 100
 #define NODE_INFO_MAX 128
 

--- a/src/commands.c
+++ b/src/commands.c
@@ -7,7 +7,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "../inc/commands.h"
+#include "commands.h"
 
 /*
  * commands:

--- a/src/croco.c
+++ b/src/croco.c
@@ -11,12 +11,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "../inc/croco.h"
+#include "croco.h"
 
-#include "../inc/commands.h"
-#include "../inc/keys.h"
-#include "../inc/files.h"
-#include "../inc/util.h"
+#include "commands.h"
+#include "keys.h"
+#include "files.h"
+#include "util.h"
 
 #ifdef _WIN32
 	perror("Not linux os\n");
@@ -76,10 +76,10 @@ size_t ndirs = 0;
 char *prev_dirs[DIRS_MAX];
 size_t nprev_dirs = 0;
 
-char cwd[PATH_MAX]; // current working directory
+char cwd[CROCO_PATH_MAX]; // current working directory
 size_t ncwd = 0;
 
-char prev_cwd[PATH_MAX]; // parent of cwd
+char prev_cwd[CROCO_PATH_MAX]; // parent of cwd
 size_t nprev_cwd = 0;
 
 size_t top_index = 0;  // cwd[top_index] will be shown on top of the main_win. it's for scrolling
@@ -255,7 +255,7 @@ void process_kb()
 				break;
 
 			case KKEY_ENTER: {
-					char path[PATH_MAX] = { '\0' };
+					char path[CROCO_PATH_MAX] = { '\0' };
 					create_path(path, cwd, dirs[highlight - 1]);
 					if (!is_file(path)) {
 						choice = highlight;
@@ -333,7 +333,7 @@ void process_kleft()
 
 void process_kright() 
 {
-	char fpath[PATH_MAX] = { '\0' };
+	char fpath[CROCO_PATH_MAX] = { '\0' };
 	create_path(fpath, cwd, dirs[highlight - 1]);
 	if (is_file(fpath)) {
 		open_file(fpath);
@@ -437,7 +437,7 @@ void get_cwd(char *cwd, int argc, char *argv[])
 		strcat(cwd, "/\0");
 		ncwd = strlen(cwd);
 	} else if (strcmp(argv[0], ".")) {
-		if (getcwd(cwd, PATH_MAX) == NULL) {
+		if (getcwd(cwd, CROCO_PATH_MAX) == NULL) {
 			end();
 			fprintf(stderr, "getcwd error\n");
 			exit(EXIT_FAILURE);
@@ -497,7 +497,7 @@ void open_wd(const char *wd, char **dirs_arr, size_t *ndirs_arr)
 	struct dirent *dir;
 	if (d) {
 		while ((dir = readdir(d)) != NULL) {
-			dirs_arr[*ndirs_arr] = malloc(PATH_MAX * sizeof(char));
+			dirs_arr[*ndirs_arr] = malloc(CROCO_PATH_MAX * sizeof(char));
 			strcpy(dirs_arr[(*ndirs_arr)++], dir->d_name);
 		}
 	} else {
@@ -573,7 +573,7 @@ void print_main()
 	for (size_t i = top_index; i < min(ndirs, top_index + MAIN_HEIGHT); ++i) {
 		pos_i = 3 + i - top_index;
 		
-		char fpath[PATH_MAX] = { '\0' };
+		char fpath[CROCO_PATH_MAX] = { '\0' };
 		create_path(fpath, cwd, dirs[i]);
 
 		if (highlight == i + 1) {
@@ -601,7 +601,7 @@ void update_main(size_t highlight)
 	for (size_t i = top_index; i < min(ndirs, top_index + MAIN_HEIGHT); ++i) {
 		pos_i = 3 + i - top_index;
 	
-		char fpath[PATH_MAX] = { '\0' };
+		char fpath[CROCO_PATH_MAX] = { '\0' };
 		create_path(fpath, cwd, dirs[i]);
 
 		if (highlight == i + 1) {
@@ -638,7 +638,7 @@ void print_linfo()
 	colored_print(linfo_win, 1, 1, prev_cwd, FOLDER_COLOR);
 
 	for (size_t i = 0; i < nprev_dirs; ++i) {
-		char fpath[PATH_MAX] = { '\0' };
+		char fpath[CROCO_PATH_MAX] = { '\0' };
 		create_path(fpath, prev_cwd, prev_dirs[i]);
 
 		if (is_file(fpath)) {
@@ -660,7 +660,7 @@ void print_rinfo()
 	wclear(rinfo_win);
 	
 	/* printing file/dir name in color in info win */	
-	char fpath[PATH_MAX] = { '\0' };
+	char fpath[CROCO_PATH_MAX] = { '\0' };
 	create_path(fpath, cwd, dirs[highlight - 1]);
 
 	if (is_file(fpath)) {
@@ -689,7 +689,7 @@ void print_rinfo()
  */
 void print_file(char *fname)
 {
-	char fpath[PATH_MAX] = { '\0' };
+	char fpath[CROCO_PATH_MAX] = { '\0' };
 	create_path(fpath, cwd, fname);
 
 	FILE *f_ptr = fopen(fpath, "r");
@@ -726,7 +726,7 @@ void print_file(char *fname)
  */
 void print_folder(char *fname)
 {
-	char fpath[PATH_MAX] = { '\0' };
+	char fpath[CROCO_PATH_MAX] = { '\0' };
 	create_path(fpath, cwd, fname);
 
 	int len = strlen(fpath);
@@ -755,7 +755,7 @@ void print_folder(char *fname)
 			}
 
 			fd_name = fdir->d_name;
-			char folder_path[PATH_MAX] = { '\0' };
+			char folder_path[CROCO_PATH_MAX] = { '\0' };
 			create_path(folder_path, fpath, fd_name);
 			// not goin to print . and .. folders in info window
 			if (strcmp(fd_name, ".") != 0 && strcmp(fd_name, "..") != 0) {

--- a/src/files.c
+++ b/src/files.c
@@ -11,7 +11,7 @@
 #include <sys/types.h>
 #include <time.h>
 
-#include "../inc/files.h"
+#include "files.h"
 
 struct stat get_stat(const char *path) 
 {

--- a/src/util.c
+++ b/src/util.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <strings.h>
 
-#include "../inc/util.h"
+#include "util.h"
 
 void sort_dirs(char *dirs[], const size_t len)
 {


### PR DESCRIPTION
Fixes various build mistakes:

In the `CMakeLists.txt`:
* CMake 3.10 is 8 years old, update to 3.23 which is merely 3 years old (really, this should be whatever version of CMake you're actually using and testing on)
* `CMAKE_C_STANDART` isn't a thing to begin with, note the `T` at the end. Anyway, never `set()` global `CMAKE_*` variables like this
* Never use directory-scoped commands like `include_directories()`
* Not using `CURSES_CFLAGS` at all, which is required for correct behavior on some systems
* Correctly use `target_*` commands to setup `croco`

In the `Makefile`
* Correctly set `-I` flag for the include folder

In C source files:
* Because you're not using `CURSES_CFLAGS`, you caused a macro collision with `PATH_MAX` which is already a Linux header macro. Renamed to `CROCO_PATH_MAX`.
* Removed relative-pathing from includes now that the include folders are being set correctly